### PR TITLE
Rename modules to avoid name clash with hxt

### DIFF
--- a/arrow-list.cabal
+++ b/arrow-list.cabal
@@ -30,9 +30,9 @@ library
   ghc-options:       -Wall
   hs-source-dirs:    src
   exposed-modules:
-    Control.Arrow.ArrowF
-    Control.Arrow.ArrowKleisli
-    Control.Arrow.ArrowList
+    Control.Arrow.Kleisli.Class
+    Control.Arrow.List.Class
+    Control.Arrow.ListLike.Class
     Control.Arrow.List
     Control.Arrow.Sequence
     Control.Monad.Sequence

--- a/src/Control/Arrow/Kleisli/Class.hs
+++ b/src/Control/Arrow/Kleisli/Class.hs
@@ -3,17 +3,17 @@ The `ArrowKleisli' type class allows for embedding monadic operations in
 Kleisli arrows.
 -}
 {-# LANGUAGE
-    TypeOperators
-  , MultiParamTypeClasses
-  , FlexibleInstances
+    FlexibleInstances
   , FunctionalDependencies
+  , MultiParamTypeClasses
+  , TypeOperators
   #-}
-module Control.Arrow.ArrowKleisli where
+module Control.Arrow.Kleisli.Class where
 
 import Control.Arrow
 import Control.Category
 import Control.Monad.Trans
-import Prelude hiding ((.), id)
+import Prelude hiding (id, (.))
 
 class (Monad m, Arrow arr) => ArrowKleisli m arr | arr -> m where
   arrM :: (a -> m b) -> a `arr` b

--- a/src/Control/Arrow/List.hs
+++ b/src/Control/Arrow/List.hs
@@ -1,20 +1,20 @@
 {-# LANGUAGE
-    GeneralizedNewtypeDeriving
-  , TypeOperators
-  , FlexibleInstances
+    FlexibleInstances
+  , GeneralizedNewtypeDeriving
   , MultiParamTypeClasses
   , StandaloneDeriving
+  , TypeOperators
   #-}
 module Control.Arrow.List where
 
-import Prelude hiding ((.), id)
 import Control.Arrow
-import Control.Arrow.ArrowKleisli
-import Control.Arrow.ArrowList
-import Control.Arrow.ArrowF
+import Control.Arrow.Kleisli.Class
+import Control.Arrow.List.Class
+import Control.Arrow.ListLike.Class
 import Control.Category
 import Control.Monad.Identity
 import Control.Monad.List
+import Prelude hiding (id, (.))
 
 -- * ListT arrow.
 
@@ -45,7 +45,7 @@ instance Monad m => ArrowList (ListTArrow m) where
   arrL a   = ListTArrow (Kleisli (ListT . return . a))
   mapL f g = arrML (liftM f . runListTArrow g)
 
-instance Monad m => ArrowF [] (ListTArrow m) where
+instance Monad m => ArrowListLike [] (ListTArrow m) where
   embed     = ListTArrow (Kleisli (ListT . return))
   observe f = ListTArrow . Kleisli $ \a -> ListT $
                 return `liftM` runListT (runKleisli (runListTArrow' f) a)

--- a/src/Control/Arrow/List/Class.hs
+++ b/src/Control/Arrow/List/Class.hs
@@ -1,10 +1,13 @@
-{-# LANGUAGE TypeOperators, Arrows #-}
+{-# LANGUAGE
+    Arrows
+  , TypeOperators
+  #-}
 {- |
 The `ArrowList' type class, and a collection of list arrow related functions.
 This typeclass can be used to embed functions producing multiple outputs into a
 an arrow.
 -}
-module Control.Arrow.ArrowList
+module Control.Arrow.List.Class
 (
   -- * ArrowList type class.
   ArrowList (..)
@@ -34,10 +37,10 @@ module Control.Arrow.ArrowList
 )
 where
 
-import Control.Monad hiding (when)
-import Control.Category
 import Control.Arrow
-import Prelude hiding ((.), id)
+import Control.Category
+import Control.Monad hiding (when)
+import Prelude hiding (id, (.))
 
 -- | The `ArrowList' class represents two possible actions:
 --

--- a/src/Control/Arrow/ListLike/Class.hs
+++ b/src/Control/Arrow/ListLike/Class.hs
@@ -1,13 +1,13 @@
 {-# LANGUAGE
-    TypeOperators
-  , Arrows
-  , MultiParamTypeClasses
+    Arrows
   , FunctionalDependencies
+  , MultiParamTypeClasses
+  , TypeOperators
   #-}
-module Control.Arrow.ArrowF
+module Control.Arrow.ListLike.Class
 (
   -- * Container arrow type class.
-  ArrowF (..)
+  ArrowListLike (..)
 , mapF
 , arrMF
 
@@ -39,10 +39,10 @@ where
 
 import Control.Applicative hiding (optional)
 import Control.Arrow
-import Control.Arrow.ArrowKleisli
+import Control.Arrow.Kleisli.Class
 import Control.Category
 import Data.Foldable (Foldable, toList)
-import Prelude hiding ((.), id, const)
+import Prelude hiding (const, id, (.))
 import qualified Prelude
 
 -- | A type class for arrows that produce containers of results. The container
@@ -50,18 +50,18 @@ import qualified Prelude
 -- assume the container type has an 'Applicative', an 'Alternative' and a
 -- 'Foldable' instance.
 
-class Arrow arr => ArrowF f arr | arr -> f where
+class Arrow arr => ArrowListLike f arr | arr -> f where
   embed   :: f a `arr` a                 -- ^ Use a container as the input for an arrow.
   observe :: (a `arr` b) -> a `arr` f b  -- ^ Get the result as container.
 
 -- | Embed a monadic function returning an ordered list into a container arrow.
 
-arrMF :: (ArrowF f arr, ArrowKleisli m arr) => (a -> m (f c)) -> a `arr` c
+arrMF :: (ArrowListLike f arr, ArrowKleisli m arr) => (a -> m (f c)) -> a `arr` c
 arrMF x = embed . arrM x
 
 -- | Map a function over the result collection of a container arrow.
 
-mapF :: ArrowF f arr => (f b -> f c) -> a `arr` b -> a `arr` c
+mapF :: ArrowListLike f arr => (f b -> f c) -> a `arr` b -> a `arr` c
 mapF f a = embed . arr f . observe a
 
 -- | Take the output of an arrow producing two results and concatenate them
@@ -82,30 +82,30 @@ concatA = foldr (<+>) zeroArrow
 
 -- | Join the results of two arrows, like (<+>) from ArrowPlus.
 
-plus :: (Alternative f, ArrowF f arr) => (a `arr` b) -> (a `arr` b) -> a `arr` b
+plus :: (Alternative f, ArrowListLike f arr) => (a `arr` b) -> (a `arr` b) -> a `arr` b
 plus a b = embed . arr (\(x, y) -> x <|> y) . (observe a &&& observe b)
 
 -- | Skip the input and produce a constant output specified as a container.
 
-constF :: ArrowF f arr => f c -> a `arr` c
+constF :: ArrowListLike f arr => f c -> a `arr` c
 constF f = embed . const f
 
 -- | Ignore the input and produce no results. Like `zeroArrow'.
 
-none :: (Alternative f, ArrowF f arr) => a `arr` b
+none :: (Alternative f, ArrowListLike f arr) => a `arr` b
 none = constF empty
 
 -- | Returns a `Bool' indicating whether the input arrow produces a container
 -- with any results.
 
-results :: (Foldable f, ArrowF f arr) => (a `arr` b) -> (a `arr` Bool)
+results :: (Foldable f, ArrowListLike f arr) => (a `arr` b) -> (a `arr` Bool)
 results a = arr (not . null . toList) . observe a
 
 -- | Create a filtering container arrow by mapping a predicate function over the
 -- input. When the predicate returns `True' the input will be returned in the
 -- output container, when `False' the empty container is returned.
 
-isA :: (Alternative f, ArrowF f arr) => (a -> Bool) -> a `arr` a
+isA :: (Alternative f, ArrowListLike f arr) => (a -> Bool) -> a `arr` a
 isA f = embed . arr (\a -> if f a then pure a else empty)
 
 -- | Use the result of a container arrow as a conditional, like an if-then-else
@@ -113,7 +113,7 @@ isA f = embed . arr (\a -> if f a then pure a else empty)
 -- used, when the first arrow produces no results the /else/ arrow will be
 -- used.
 
-ifA :: (Foldable f, ArrowF f arr, ArrowChoice arr) => (a `arr` b) -> (a `arr` t) -> (a `arr` t) -> a `arr` t
+ifA :: (Foldable f, ArrowListLike f arr, ArrowChoice arr) => (a `arr` b) -> (a `arr` t) -> (a `arr` t) -> a `arr` t
 ifA c t e = proc i -> do x <- results c -< i; if x then t -< i else e -< i
 
 -- | Apply a container arrow only when a conditional arrow produces any
@@ -123,7 +123,7 @@ ifA c t e = proc i -> do x <- results c -< i; if x then t -< i else e -< i
 
 infix 7 `when`
 
-when :: (Foldable f, ArrowF f arr, ArrowChoice arr) => (a `arr` a) -> (a `arr` c) -> a `arr` a
+when :: (Foldable f, ArrowListLike f arr, ArrowChoice arr) => (a `arr` a) -> (a `arr` c) -> a `arr` a
 when a c = ifA c a id
 
 -- | Apply a container arrow only when a conditional arrow produces any
@@ -133,19 +133,19 @@ when a c = ifA c a id
 
 infix 8 `guards`
 
-guards :: (Alternative f, Foldable f, ArrowF f arr, ArrowChoice arr) => (a `arr` c) -> (a `arr` b) -> (a `arr` b)
+guards :: (Alternative f, Foldable f, ArrowListLike f arr, ArrowChoice arr) => (a `arr` c) -> (a `arr` b) -> (a `arr` b)
 guards c a = ifA c a none
 
 -- | Filter the results of an arrow with a predicate arrow, when the filter
 -- condition produces results the input is accepted otherwise it is excluded.
 
-filterA :: (Alternative f, Foldable f, ArrowF f arr, ArrowChoice arr) => (a `arr` c) -> a `arr` a
+filterA :: (Alternative f, Foldable f, ArrowListLike f arr, ArrowChoice arr) => (a `arr` c) -> a `arr` a
 filterA c = ifA c id none
 
 -- | Negation container arrow. Only accept the input when the condition
 -- produces no output.
 
-notA :: (Alternative f, Foldable f, ArrowF f arr, ArrowChoice arr) => (a `arr` c) -> a `arr` a
+notA :: (Alternative f, Foldable f, ArrowListLike f arr, ArrowChoice arr) => (a `arr` c) -> a `arr` a
 notA c = ifA c none id
 
 -- | Apply the input arrow, when the arrow does not produces any results the
@@ -154,19 +154,19 @@ notA c = ifA c none id
 
 infix 6 `orElse`
 
-orElse :: (Foldable f, ArrowF f arr, ArrowChoice arr) => (a `arr` b) -> (a `arr` b) -> a `arr` b
+orElse :: (Foldable f, ArrowListLike f arr, ArrowChoice arr) => (a `arr` b) -> (a `arr` b) -> a `arr` b
 orElse a = ifA a a
 
 -- | Map a `Maybe' input to a container output. When the Maybe is a `Nothing'
 -- an empty container will be returned, `Just' will result in a singleton
 -- container.
 
-maybeA :: (Alternative f, ArrowF f arr) => Maybe a `arr` a
+maybeA :: (Alternative f, ArrowListLike f arr) => Maybe a `arr` a
 maybeA = embed . arr (maybe empty pure)
 
 -- | Apply a container arrow, when there are no results a `Nothing' will be
 -- returned, otherwise the results will be wrapped in a `Just'. This function
 -- always produces result.
 
-optional :: (Foldable f, ArrowF f arr, ArrowChoice arr) => (a `arr` b) -> a `arr` Maybe b
+optional :: (Foldable f, ArrowListLike f arr, ArrowChoice arr) => (a `arr` b) -> a `arr` Maybe b
 optional a = ifA a (arr Just . a) (arr (const Nothing))

--- a/src/Control/Arrow/Sequence.hs
+++ b/src/Control/Arrow/Sequence.hs
@@ -1,20 +1,20 @@
 {-# LANGUAGE
-    GeneralizedNewtypeDeriving
-  , TypeOperators
-  , FlexibleInstances
+    FlexibleInstances
+  , GeneralizedNewtypeDeriving
   , MultiParamTypeClasses
   , StandaloneDeriving
+  , TypeOperators
   #-}
 module Control.Arrow.Sequence where
 
 import Control.Arrow
-import Control.Arrow.ArrowF
-import Control.Arrow.ArrowKleisli
+import Control.Arrow.Kleisli.Class
+import Control.Arrow.ListLike.Class
 import Control.Category
 import Control.Monad.Identity
 import Control.Monad.Sequence
 import Data.Sequence
-import Prelude hiding ((.), id, const)
+import Prelude hiding (const, id, (.))
 
 -- * SeqT arrow.
 
@@ -41,7 +41,7 @@ type SeqArrow a b = SeqTArrow Identity a b
 runSeqArrow :: SeqArrow a b -> a -> Seq b
 runSeqArrow a = runIdentity . runSeqTArrow a
 
-instance Monad m => ArrowF Seq (SeqTArrow m) where
+instance Monad m => ArrowListLike Seq (SeqTArrow m) where
   embed     = SeqTArrow (Kleisli (SeqT . return))
   observe f = SeqTArrow . Kleisli $ \a -> SeqT $
                 singleton `liftM` runSeqT (runKleisli (runSeqTArrow' f) a)


### PR DESCRIPTION
Module renames

```
-    Control.Arrow.ArrowF
+    Control.Arrow.ArrowListLike.Class

-    Control.Arrow.ArrowKleisli
+    Control.Arrow.ArrowKleisli.Class

-    Control.Arrow.ArrowList
+    Control.Arrow.ArrowList.Class
```

Also renames the `ArrowF` class to `ArrowListLike` to match the module name.

Thoughts?
