### PR TITLE
Fixing parse error for the indentation of preprocessor #if

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 dist/
+dist-newstyle/
 *.swp

--- a/arrow-list.cabal
+++ b/arrow-list.cabal
@@ -1,5 +1,5 @@
 name:                arrow-list
-version:             0.7.1
+version:             0.7.2
 synopsis:            List arrows for Haskell.
 description:
   This small Haskell library provides some type class, types and functions to

--- a/src/Control/Monad/Sequence.hs
+++ b/src/Control/Monad/Sequence.hs
@@ -57,9 +57,9 @@ instance Monad m => Monad (SeqT m) where
     do a <- runSeqT m
        b <- mapM (runSeqT . k) a
        return (msum b)
-  #if !MIN_VERSION_base(4,13,0)
+#if !MIN_VERSION_base(4,13,0)
   fail _ = SeqT (return mempty)
-  #endif
+#endif
 
 instance Monad m => MonadFail (SeqT m) where
   fail _ = SeqT (return mempty)


### PR DESCRIPTION
Hello Team,

# Issue
I just came across a parse error on the preprocessor `#if` and found that the indentation was the issue, while the indent is complete fine with C preprocessors, `ghc` seems to be unhappy with that.

# Possible Fix
The possible fix would be removing the indentation of the preprocessor `#if`, (`#else`) and `#endif`.

---
Thank you and please do not hesitate to let me know if you have any comments or if you would like to have any changes.

Best Regards,
Leo